### PR TITLE
fix: Add empty note validation to prevent submitting blank content

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -33,6 +33,10 @@ const statusUpdates = {
     message: "No path",
     iconClass: "text-red-500"
   },
+  empty_content: {
+    message: "Empty note",
+    iconClass: "text-red-500"
+  },
   stash_saved: {
     message: "Stashed",
     iconClass: "text-blue-500"
@@ -138,6 +142,12 @@ async function handleKeyDown(event) {
     const thought = thoughtInputEl.value;
     const mode = document.querySelector("#save-mode").value;
     const path = mode === "daily" ? dailyPath : standalonePath;
+
+    // Check if the content is empty or only whitespace
+    if (!thought.trim()) {
+      updateStatus("empty_content");
+      return;
+    }
 
     // Check if the path is empty
     if (!path) {


### PR DESCRIPTION
## Summary
- Prevents users from submitting empty or whitespace-only notes
- Shows "Empty note" error status with red icon for 3 seconds
- Validates content before checking path configuration

## Fixes issue #36

## Test plan
- [x] Try to submit completely empty note with Cmd+Enter - should show "Empty note" error
- [x] Try to submit note with only spaces/tabs - should show "Empty note" error  
- [x] Try to submit note with actual content - should work normally
- [x] Verify existing functionality still works (path validation, etc.)